### PR TITLE
Fix symmetric decrypt error message

### DIFF
--- a/pkg/crypto/symmetric/symmetric.go
+++ b/pkg/crypto/symmetric/symmetric.go
@@ -95,7 +95,7 @@ func (encryptor *aesEncryptor) Encrypt(data []byte) ([]byte, error) {
 // It returns a plain-text slice of data and an error if any occurs during the decryption process.
 func (encryptor *aesEncryptor) Decrypt(encryptedData []byte) ([]byte, error) {
 	if len(encryptedData) < aes.BlockSize {
-		return nil, fmt.Errorf("cipher-text of len %d is shorter then the minimum length of %d", len(encryptedData), aes.BlockSize)
+		return nil, fmt.Errorf("cipher-text of len %d is shorter than the minimum length of %d", len(encryptedData), aes.BlockSize)
 	}
 
 	iv := encryptedData[:aes.BlockSize]

--- a/pkg/crypto/symmetric/symmetric_test.go
+++ b/pkg/crypto/symmetric/symmetric_test.go
@@ -70,7 +70,7 @@ func TestSymmetricEncryption(t *testing.T) {
 		t.Parallel()
 		encryptor := newEncryptor(t)
 		decrypted, err := encryptor.Decrypt(nil)
-		assert.ErrorPart(t, err, "shorter then the minimum length")
+		assert.ErrorPart(t, err, "shorter than the minimum length")
 		assert.Nil(t, decrypted)
 	})
 


### PR DESCRIPTION
## Summary
- typo fix: "shorter then" -> "shorter than" when decrypting
- update tests to match

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f7489175c8324943bbe7bf92e4ff8