### PR TITLE
Add Content-Type assertion in JSON responder test

### DIFF
--- a/pkg/http/responders/json_responder_test.go
+++ b/pkg/http/responders/json_responder_test.go
@@ -50,6 +50,7 @@ func TestJSONResponder(t *testing.T) {
 		response, err := http.Post(server.URL, headers.ContentTypeApplicationJson, strings.NewReader(`{"id":123}`))
 		assert.NoError(t, err)
 		assert.Equals(t, response.StatusCode, http.StatusOK)
+		assert.Equals(t, response.Header.Get(headers.ContentType), headers.ContentTypeApplicationJson)
 		assert.NoError(t, writeError)
 
 		body := &responseBody{}


### PR DESCRIPTION
## Summary
- ensure JSON responder sets Content-Type header to `application/json`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f74aea9a88324a9a6f6616dd55fe9