### PR TITLE
Fix typos and clarify comments

### DIFF
--- a/pkg/datastructures/cache/cache.go
+++ b/pkg/datastructures/cache/cache.go
@@ -16,7 +16,7 @@ type getOrSetKeyLock[Value any] struct {
 	FnError  error
 }
 
-// Cache is an implementation of the Cache interface.
+// Cache stores key/value pairs with optional expiration.
 type Cache[Key comparable, Value any] struct {
 	rwMutex          sync.RWMutex
 	getOrSetLock     sync.Mutex

--- a/pkg/reflection/dereference.go
+++ b/pkg/reflection/dereference.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-// DereferenceNil is returned Dereference is called with nil pointers.
+// DereferenceNil is returned when Dereference is called with nil pointers.
 type DereferenceNil struct{}
 
 // Error ensures DereferenceNil implements the error interface.
@@ -12,8 +12,8 @@ func (d *DereferenceNil) Error() string {
 	return "found nil while dereferencing"
 }
 
-// Dereference returns the value after all pointers and interfaces.
-// Is case of types that can be nil but aren't pointers, like maps or slices, it does nothing.
+// Dereference returns the value after dereferencing pointers and interfaces.
+// In the case of types that can be nil but aren't pointers, such as maps or slices, it does nothing.
 func Dereference(value reflect.Value) (reflect.Value, error) {
 	for value.Kind() == reflect.Ptr || value.Kind() == reflect.Interface {
 		if IsNil(value) {

--- a/pkg/structs/assign.go
+++ b/pkg/structs/assign.go
@@ -56,7 +56,7 @@ func AssignToField[T any](obj *T, fieldName string, stringEncodedValue string) e
 		// If the field type implements encoding.TextUnmarshaler, the interface is used parse the value.
 		unmarshaler := fieldPtr.Interface().(encoding.TextUnmarshaler)
 		if err := unmarshaler.UnmarshalText([]byte(stringEncodedValue)); err != nil {
-			return fmt.Errorf("text unmarshall error (%w)", err)
+			return fmt.Errorf("text unmarshal error (%w)", err)
 		}
 	} else {
 		// If the field type is basic, the value is set directly.


### PR DESCRIPTION
## Summary
- fix comment on Cache type
- fix Dereference comments
- fix typo in AssignToField error message

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840dbe2e3e083248b79942d03246a7e