### PR TITLE
Fix typos in comments

### DIFF
--- a/pkg/crypto/symmetric/symmetric.go
+++ b/pkg/crypto/symmetric/symmetric.go
@@ -76,7 +76,7 @@ func New(key string, opts ...Option) (Encryptor, error) {
 }
 
 // Encrypt takes a slice of data and returns an encrypted version of that data using the AES algorithm.
-// It returns a cypher-text slice of data and an error if any occurs during the encryption process.
+// It returns a ciphertext slice of data and an error if any occurs during the encryption process.
 func (encryptor *aesEncryptor) Encrypt(data []byte) ([]byte, error) {
 	ciphertext := make([]byte, aes.BlockSize+len(data))
 

--- a/pkg/datastructures/heap/heap.go
+++ b/pkg/datastructures/heap/heap.go
@@ -35,7 +35,7 @@ import (
 
 // A heap can be represented as a complete binary tree. Using a complete binary tree ensures
 // the tree is always balanced. The key property of this representation is that each child
-// must be bigger (if using max heap) then its children. It does not matter if the children
+// must be bigger (if using max heap) than its children. It does not matter if the children
 // are sorted. This ensures the root node is always the largest.
 //
 //       10
@@ -100,7 +100,7 @@ func (h *Heap[T]) Size() int {
 	return len(h.tree)
 }
 
-// Push adds a new values to the heap.
+// Push adds a new value to the heap.
 func (h *Heap[T]) Push(value T) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
@@ -118,7 +118,7 @@ func (h *Heap[T]) Push(value T) {
 }
 
 // Pop removes the largest or smallest element (depending on the comparator) from the heap.
-// It panics if there is no values in the heap.
+// It panics if the heap is empty.
 func (h *Heap[T]) Pop() T {
 	h.lock.Lock()
 	defer h.lock.Unlock()
@@ -170,7 +170,7 @@ func (h *Heap[T]) Pop() T {
 }
 
 // Peek returns the min or max value on this heap. The access is O(1).
-// It panics if there is no values in the heap.
+// It panics if the heap is empty.
 func (h *Heap[T]) Peek() T {
 	h.lock.RLock()
 	defer h.lock.RUnlock()

--- a/pkg/http/parameters/tags.go
+++ b/pkg/http/parameters/tags.go
@@ -61,7 +61,7 @@ var (
 		},
 	}
 
-	// lookupKeyFollowsNamingConvention is used to verify that a tags lookup key follow the naming convention as defined by TagLookupKeyNamingConvention.
+	// lookupKeyFollowsNamingConvention verifies that a tag's lookup key follows the naming convention defined by TagLookupKeyNamingConvention.
 	lookupKeyFollowsNamingConvention func(lookupKey string) bool
 
 	// lookupKeyExtractionCache stores the results of the ExtractAndValidateFieldTagLookupKeys function.

--- a/pkg/logger/level.go
+++ b/pkg/logger/level.go
@@ -26,7 +26,7 @@ func SetLevel(level LogLevel) {
 	appLogLevel = level
 }
 
-// GetLevel returns the applications log level.
+// GetLevel returns the application's log level.
 func GetLevel() LogLevel {
 	lock.RLock()
 	defer lock.RUnlock()

--- a/pkg/structs/assign.go
+++ b/pkg/structs/assign.go
@@ -19,7 +19,7 @@ func AssignToField[T any](obj *T, fieldName string, stringEncodedValue string) e
 		panic("obj must be a pointer to a struct")
 	}
 
-	// Get the field metadata for all the structs fields.
+	// Get the field metadata for all the struct's fields.
 	fieldsToMetadata := Metadata[T]()
 	fieldMetadata, foundFieldMetadata := fieldsToMetadata.Fetch(fieldName)
 	if !foundFieldMetadata {
@@ -98,7 +98,7 @@ func AssignToField[T any](obj *T, fieldName string, stringEncodedValue string) e
 	}
 
 	// If the field is a ptr, set the ptr to the newly allocated value in fieldPtr.
-	// If the field it not a ptr, copy the contents of fieldPtr into it.
+	// If the field is not a ptr, copy the contents of fieldPtr into it.
 	if originalFieldType.Kind() == reflect.Ptr {
 		structFieldValue.Set(fieldPtr)
 	} else {

--- a/pkg/structs/field_metadata.go
+++ b/pkg/structs/field_metadata.go
@@ -6,7 +6,7 @@ import (
 	"github.com/TriangleSide/GoTools/pkg/datastructures/readonly"
 )
 
-// FieldMetadata is the metadata extracted a struct fields.
+// FieldMetadata is the metadata extracted from struct fields.
 type FieldMetadata struct {
 	reflectType reflect.Type
 	tags        *readonly.Map[string, string]

--- a/pkg/structs/metadata.go
+++ b/pkg/structs/metadata.go
@@ -18,12 +18,12 @@ var (
 	typeToMetadataCache = cache.New[reflect.Type, *readonly.Map[string, *FieldMetadata]]()
 )
 
-// Metadata returns a map of a structs field names to their respective metadata.
+// Metadata returns a map of a struct's field names to their respective metadata.
 func Metadata[T any]() *readonly.Map[string, *FieldMetadata] {
 	return MetadataFromType(reflect.TypeFor[T]())
 }
 
-// MetadataFromType returns a map of a structs field names to their respective metadata.
+// MetadataFromType returns a map of a struct's field names to their respective metadata.
 func MetadataFromType(reflectType reflect.Type) *readonly.Map[string, *FieldMetadata] {
 	fieldsToMetadata, _ := typeToMetadataCache.GetOrSet(reflectType, func(reflectType reflect.Type) (*readonly.Map[string, *FieldMetadata], *time.Duration, error) {
 		fieldsToMetadata := make(map[string]*FieldMetadata)

--- a/pkg/structs/value_from_name.go
+++ b/pkg/structs/value_from_name.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 )
 
-// ValueFromName returns the fields value if it exists.
+// ValueFromName returns the field's value if it exists.
 func ValueFromName[T any](structInstance T, fieldName string) (reflect.Value, error) {
 	reflectVal := reflect.ValueOf(structInstance)
 	if reflectVal.Kind() == reflect.Ptr {

--- a/pkg/validation/register_required.go
+++ b/pkg/validation/register_required.go
@@ -13,7 +13,7 @@ func init() {
 	})
 }
 
-// required check if the value is a zero value for its type.
+// required checks if the value is a zero value for its type.
 func required(params *CallbackParameters) *CallbackResult {
 	result := NewCallbackResult()
 

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -27,7 +27,7 @@ const (
 	//     Value *int `validate:"required,gt=0"`
 	// }
 	//
-	// The tag contents contains the validators and their respective instructions.
+	// The tag contains the validators and their respective instructions.
 	Tag = "validate"
 )
 


### PR DESCRIPTION
## Summary
- clean up typos in comments across the repo
- keep comments brief and accurate

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840de3773f88324b84f3a7b88b9b4ab