### PR TITLE
Fix comment wording

### DIFF
--- a/pkg/datastructures/cache/cache.go
+++ b/pkg/datastructures/cache/cache.go
@@ -35,7 +35,7 @@ func New[Key comparable, Value any]() *Cache[Key, Value] {
 	}
 }
 
-// item are the values that are held in the Cache's map.
+// item is the value stored in the Cache's map.
 type item[Value any] struct {
 	value  Value
 	expiry *time.Time

--- a/pkg/datastructures/readonly/map.go
+++ b/pkg/datastructures/readonly/map.go
@@ -42,7 +42,7 @@ func (r *Map[Key, Value]) Keys() []Key {
 	return keys
 }
 
-// All iterates over the values of the map.
+// All iterates over the key/value pairs of the map.
 func (r *Map[Key, Value]) All() iter.Seq2[Key, Value] {
 	return func(yield func(Key, Value) bool) {
 		for key, value := range r.internalMap {


### PR DESCRIPTION
## Summary
- correct grammatical issue in Cache's item comment
- clarify Map.All iterates over key/value pairs

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840e34926308324b95fbda9321723c2