### PR TITLE
Add detailed errors for JWT header

### DIFF
--- a/pkg/jwt/header.go
+++ b/pkg/jwt/header.go
@@ -1,0 +1,39 @@
+package jwt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// MarshalFunc is used for JSON marshaling and can be overwritten in tests.
+var MarshalFunc = json.Marshal
+
+// Header represents the header portion of a JSON Web Token.
+type Header struct {
+	Algorithm string `json:"alg"`
+	Type      string `json:"typ,omitempty"`
+	KeyID     string `json:"kid,omitempty"`
+}
+
+// EncodeHeader serializes the Header and returns a base64 URL encoded string without padding.
+func EncodeHeader(h Header) (string, error) {
+	data, err := MarshalFunc(h)
+	if err != nil {
+		return "", fmt.Errorf("json marshal error (%w)", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+// DecodeHeader decodes a base64 URL encoded header string into a Header struct.
+func DecodeHeader(encoded string) (*Header, error) {
+	data, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode error (%w)", err)
+	}
+	var h Header
+	if err := json.Unmarshal(data, &h); err != nil {
+		return nil, fmt.Errorf("json unmarshal error (%w)", err)
+	}
+	return &h, nil
+}

--- a/pkg/jwt/header_test.go
+++ b/pkg/jwt/header_test.go
@@ -1,0 +1,53 @@
+package jwt_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/TriangleSide/GoTools/pkg/jwt"
+	"github.com/TriangleSide/GoTools/pkg/test/assert"
+)
+
+func TestJWTHeader(t *testing.T) {
+	t.Run("it should encode and decode a header", func(t *testing.T) {
+		original := jwt.Header{Algorithm: "HS256", Type: "JWT", KeyID: "1"}
+		encoded, err := jwt.EncodeHeader(original)
+		assert.NoError(t, err)
+		assert.NotEquals(t, encoded, "")
+
+		decoded, err := jwt.DecodeHeader(encoded)
+		assert.NoError(t, err)
+		assert.Equals(t, *decoded, original)
+	})
+
+	t.Run("when encoded string is invalid base64 it should return an error", func(t *testing.T) {
+		decoded, err := jwt.DecodeHeader("!invalid-base64!")
+		assert.ErrorPart(t, err, "base64 decode error")
+		assert.Nil(t, decoded)
+	})
+
+	t.Run("when encoded string is not valid JSON it should return an error", func(t *testing.T) {
+		invalid := base64.RawURLEncoding.EncodeToString([]byte("not-json"))
+		decoded, err := jwt.DecodeHeader(invalid)
+		assert.ErrorPart(t, err, "json unmarshal error")
+		assert.Nil(t, decoded)
+	})
+
+	t.Run("when encoded string contains json with wrong types it should return an error", func(t *testing.T) {
+		invalid := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":123}`))
+		decoded, err := jwt.DecodeHeader(invalid)
+		assert.ErrorPart(t, err, "json unmarshal error")
+		assert.Nil(t, decoded)
+	})
+
+	t.Run("when json marshal fails it should return an error", func(t *testing.T) {
+		originalMarshal := jwt.MarshalFunc
+		defer func() { jwt.MarshalFunc = originalMarshal }()
+
+		jwt.MarshalFunc = func(v any) ([]byte, error) { return nil, errors.New("marshal fail") }
+		encoded, err := jwt.EncodeHeader(jwt.Header{})
+		assert.ErrorPart(t, err, "json marshal error")
+		assert.Equals(t, encoded, "")
+	})
+}


### PR DESCRIPTION
## Summary
- return descriptive errors from `EncodeHeader` and `DecodeHeader`
- verify the error messages in `TestJWTHeader`
- remove unused header.md documentation file

## Testing
- `go test ./...`
- `go test ./pkg/jwt -cover`


------
https://chatgpt.com/codex/tasks/task_e_68436e6210e48324aebc8f04aa94e332