### PR TITLE
Add JWT hashing utility

### DIFF
--- a/pkg/jwt/hash.go
+++ b/pkg/jwt/hash.go
@@ -1,0 +1,29 @@
+package jwt
+
+import (
+	"crypto/hmac"
+	"encoding/base64"
+	"fmt"
+	"hash"
+)
+
+// hashData returns a base64 URL encoded HMAC string using the provided hash provider.
+func hashData(data, secret string, provider func() hash.Hash) (string, error) {
+	if provider == nil {
+		return "", fmt.Errorf("hash provider cannot be nil")
+	}
+	mac := hmac.New(provider, []byte(secret))
+	if _, err := mac.Write([]byte(data)); err != nil {
+		return "", fmt.Errorf("failed to write data to hash (%w)", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+// verifyHash checks if the encoded hash matches the data and secret using the given provider.
+func verifyHash(encoded, data, secret string, provider func() hash.Hash) (bool, error) {
+	computed, err := hashData(data, secret, provider)
+	if err != nil {
+		return false, err
+	}
+	return hmac.Equal([]byte(computed), []byte(encoded)), nil
+}

--- a/pkg/jwt/hash_test.go
+++ b/pkg/jwt/hash_test.go
@@ -1,0 +1,72 @@
+package jwt
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"errors"
+	"hash"
+	"testing"
+
+	"github.com/TriangleSide/GoTools/pkg/test/assert"
+)
+
+// failingHash implements hash.Hash and always fails on Write.
+type failingHash struct {
+	v int
+}
+
+func (f *failingHash) Write(p []byte) (n int, err error) { return 0, errors.New("write fail") }
+func (f *failingHash) Sum(b []byte) []byte               { return []byte{} }
+func (f *failingHash) Reset()                            {}
+func (f *failingHash) Size() int                         { return 1 }
+func (f *failingHash) BlockSize() int                    { return 1 }
+
+func TestHash(t *testing.T) {
+	t.Run("it should hash and verify data", func(t *testing.T) {
+		hashed, err := hashData("payload", "secret", sha256.New)
+		assert.NoError(t, err)
+		ok, err := verifyHash(hashed, "payload", "secret", sha256.New)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("when hashes do not match it should return false", func(t *testing.T) {
+		hashed, err := hashData("payload", "secret", sha256.New)
+		assert.NoError(t, err)
+		ok, err := verifyHash(hashed+"extra", "payload", "secret", sha256.New)
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("it should use a custom hash provider", func(t *testing.T) {
+		hashed, err := hashData("payload", "secret", sha512.New)
+		assert.NoError(t, err)
+		ok, err := verifyHash(hashed, "payload", "secret", sha512.New)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("when the provider is nil it should return an error", func(t *testing.T) {
+		h, err := hashData("payload", "secret", nil)
+		assert.ErrorPart(t, err, "hash provider cannot be nil")
+		assert.Equals(t, h, "")
+	})
+
+	t.Run("when the hash provider returns an error on write it should return an error", func(t *testing.T) {
+		h, err := hashData("payload", "secret", func() hash.Hash { return &failingHash{} })
+		assert.ErrorPart(t, err, "failed to write data to hash")
+		assert.Equals(t, h, "")
+	})
+
+	t.Run("when verify uses a failing hash provider it should return an error", func(t *testing.T) {
+		ok, err := verifyHash("", "payload", "secret", func() hash.Hash { return &failingHash{} })
+		assert.ErrorPart(t, err, "failed to write data to hash")
+		assert.False(t, ok)
+	})
+
+	t.Run("when verify is called with a nil provider it should return an error", func(t *testing.T) {
+		ok, err := verifyHash("", "payload", "secret", nil)
+		assert.ErrorPart(t, err, "hash provider cannot be nil")
+		assert.False(t, ok)
+	})
+}


### PR DESCRIPTION
## Summary
- add hash.go with configurable HMAC hashing for JWT
- add unit tests for hash.go
- refactor to require explicit hash provider instead of defaulting to SHA256
- style: collapse comments for hash helpers into single lines

## Testing
- `go test ./...`
- `go test ./pkg/jwt -coverprofile=/tmp/cover.out`


------
https://chatgpt.com/codex/tasks/task_e_684776c9665c832496931a61fd685fb5